### PR TITLE
Manually peg docker-py version, pending ansible bug fix

### DIFF
--- a/ansible/box/software.yml
+++ b/ansible/box/software.yml
@@ -81,8 +81,12 @@
       pip:
         name: "{{item}}"
       with_items:
-        - docker-py
         - docker-compose
+
+    - name: hard lock docker-py for ansible bug
+      pip:
+        name: docker-py
+        version: 1.9.0
 
     - name: login to ooyala repo
       docker_login:


### PR DESCRIPTION
ansible requires a version of docker-py greater than 1.7.0. The latest is version 1.10. Python evaluates this stupidly, borks as per:

```python
>>> '1.9.0' > '1.7.0'
True
>>> '1.10.0' > '1.7.0'
False
```

Thus: fix this until ansible or whoever hack around a python bug.

Python.