### PR TITLE
Link local consul to monitoreador

### DIFF
--- a/ansible/box/software.yml
+++ b/ansible/box/software.yml
@@ -199,3 +199,5 @@
           SYSTEM_NAME: "flex-{{clusterid}}"
           SYSTEM_DESCRIPTION: "Physical host for flex {{clusterid}}"
           CONTROL_DIR: /var/tmp/control
+          CONSUL_NODENAME: "{{ ansible_hostname }}"
+          CONSUL_HTTP_ADDR: "{{ ansible_default_ipv4.address }}:8500"

--- a/ansible/cluster/software.yml
+++ b/ansible/cluster/software.yml
@@ -333,6 +333,8 @@
           SYSTEM_CODE: "{{ ipcode }}"
           SYSTEM_DESCRIPTION: "flex {{clusterid}} ec2 instance"
           CONTROL_DIR: /var/tmp/control
+          CONSUL_NODENAME: "{{ ansible_hostname }}"
+          CONSUL_HTTP_ADDR: "{{ansible_default_ipv4.address }}:8500"
 
     - name: start annihilator
       docker_container:


### PR DESCRIPTION
https://github.com/jspc/monitoreador now hooks into consul, where applicable, to include serf statuses. This adds missing environment variables to make that happen.