### PR TITLE
Mount entire stuff directory for jars

### DIFF
--- a/ansible/templates/docker-compose-components/master-10-master.yml
+++ b/ansible/templates/docker-compose-components/master-10-master.yml
@@ -21,6 +21,7 @@
     volumes:
       - /stuff/mio-enterprise/logs:/opt/jboss-eap-6.3/standalone/log
       - /stuff/mio-enterprise/storage:/flex/flex-enterprise/storage
+      - /stuff:/stuff
     extra_hosts:
       - consul:{{ ansible_default_ipv4.address }}
     hostname: {{ domain }}


### PR DESCRIPTION
Given the need to load jars from filesystem, temporarily mount the entire /stuff directory of a cluster, heavy handedly giving correct access.