### PR TITLE
Boot s3-club-7 container

### DIFF
--- a/ansible/templates/docker-compose-components/utility-10-s3club7.yml
+++ b/ansible/templates/docker-compose-components/utility-10-s3club7.yml
@@ -1,0 +1,5 @@
+  s3-club-7:
+    image: quay.io/financialtimes/s3-club-7
+    command: -cluster {{clusterid}} -flex-api https://master-flex-{{clusterid}}.ft.com/api/metadataDefinitions/
+    ports:
+      - 8000


### PR DESCRIPTION
Include s3-club-7.

Requires:

https://github.com/Financial-Times/s3-club-7/pull/3

and 

https://github.com/Financial-Times/annihilator/pull/1

merged, released and running