### PR TITLE
Removed $:<< construct from requires for platform compatibility and idiomaticity.

### DIFF
--- a/src/configure_consul
+++ b/src/configure_consul
@@ -1,7 +1,6 @@
 #!/usr/bin/env ruby
 
-$:<< './lib'
-require 'consul'
+require_relative 'lib/consul'
 
 def get key
   ENV.fetch(key)

--- a/src/lib/consul.rb
+++ b/src/lib/consul.rb
@@ -96,7 +96,7 @@ class Consul
     put('flex/enterprise/api/url', api)
     put('flex/shared/flex-enterprise/api/url', api)
     put('flex/shared/flex-enterprise/consoleUrl', api)
-    put('flex/enterprise/consoleUrl', fqdn)
+    put('flex/shared/flex-enterprise/consoleUrl', fqdn)
 
     put('annihilator/flex/metadata_domain', metadata)
     put('annihilator/flex/workflow_domain', workflow)

--- a/src/lib/consul.rb
+++ b/src/lib/consul.rb
@@ -96,7 +96,7 @@ class Consul
     put('flex/enterprise/api/url', api)
     put('flex/shared/flex-enterprise/api/url', api)
     put('flex/shared/flex-enterprise/consoleUrl', api)
-    put('flex/shared/flex-enterprise/consoleUrl', fqdn)
+    put('flex/enterprise/consoleUrl', fqdn)
 
     put('annihilator/flex/metadata_domain', metadata)
     put('annihilator/flex/workflow_domain', workflow)

--- a/src/set_vars
+++ b/src/set_vars
@@ -3,8 +3,7 @@
 require 'optparse'
 require 'inifile'
 
-$:<< './lib'
-require 'aws'
+require_relative 'aws'
 
 
 # Load the same creds as used by ansible and the CLI tool

--- a/src/set_vars
+++ b/src/set_vars
@@ -3,7 +3,7 @@
 require 'optparse'
 require 'inifile'
 
-require_relative 'aws'
+require_relative '../src/lib/aws'
 
 
 # Load the same creds as used by ansible and the CLI tool

--- a/src/set_vars
+++ b/src/set_vars
@@ -3,7 +3,7 @@
 require 'optparse'
 require 'inifile'
 
-require_relative '../src/lib/aws'
+require_relative 'lib/aws'
 
 
 # Load the same creds as used by ansible and the CLI tool

--- a/src/spec/lib/aws_spec.rb
+++ b/src/spec/lib/aws_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require_relative '../spec_helper'
 
 describe 'AWS' do
   let(:aws_connection) { build(:aws) }

--- a/src/spec/lib/consul_spec.rb
+++ b/src/spec/lib/consul_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require_relative '../spec_helper'
 
 shared_examples 'kv_with_a_value' do
   it 'correctly sets the value' do


### PR DESCRIPTION
@jspc edit:

(To save @Dazzla the work so we can get this merged).

Running the create consul configuration steps in ansible on the local host seems to fail because the working directory of the script isn't set to the directory the script exists in. Thsi behaviour seems to have changed in recent ansible.

While it would work were we to just set the working directory inside ansible, this more masks the issue. This approach is more idiomatic ruby.